### PR TITLE
fix https://github.com/alibaba/AndFix/issues/353

### DIFF
--- a/src/com/alipay/euler/andfix/Compat.java
+++ b/src/com/alipay/euler/andfix/Compat.java
@@ -57,6 +57,7 @@ public class Compat {
 	private static boolean isYunOS() {
 		String version = null;
 		String vmName = null;
+		boolean yunosLibExists = false;
 		try {
 			Method m = Class.forName("android.os.SystemProperties").getMethod(
 					"get", String.class);
@@ -65,8 +66,14 @@ public class Compat {
 		} catch (Exception e) {
 			// nothing todo
 		}
+		try {
+			yunosLibExists = new File("/system/lib/libaoc.so").exists()
+					|| new File("/system/lib/libvmkid_lemur.so").exists();
+		} catch (Exception e) {
+			// nothing todo
+		}
 		if ((vmName != null && vmName.toLowerCase().contains("lemur"))
-				|| (version != null && version.trim().length() > 0)) {
+				|| (version != null && version.trim().length() > 0) || yunosLibExists) {
 			return true;
 		} else {
 			return false;


### PR DESCRIPTION
部分云OS设备（如联想17TV55S9i）会『定制化』系统属性，导致Compat.isYunOS判断为false，修改isYunOS的实现，增加对云OS部分so库文件的判断。